### PR TITLE
EW-1414: SPSH mapper reset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,30 @@
             <artifactId>json-path</artifactId>
             <version>2.9.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>3.1.7</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.spsh</groupId>
@@ -46,9 +46,15 @@
             <version>26.2.5</version>
         </dependency>
         <dependency>
-        <groupId>org.apache.httpcomponents.client5</groupId>
-        <artifactId>httpclient5</artifactId>
-        <version>5.5</version>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-ldap-federation</artifactId>
+            <version>26.2.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.5</version>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
@@ -78,6 +84,11 @@
             <artifactId>jersey-common</artifactId>
             <version>3.1.7</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20250517</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/spsh/ldap/ErwinPortalLdapStorageMapper.java
+++ b/src/main/java/com/spsh/ldap/ErwinPortalLdapStorageMapper.java
@@ -1,0 +1,178 @@
+package com.spsh.ldap;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import javax.naming.AuthenticationException;
+
+import org.jboss.logging.Logger;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.storage.ldap.LDAPStorageProvider;
+import org.keycloak.storage.ldap.idm.model.LDAPObject;
+import org.keycloak.storage.ldap.idm.query.internal.LDAPQuery;
+import org.keycloak.storage.ldap.mappers.LDAPStorageMapper;
+import org.keycloak.storage.user.SynchronizationResult;
+
+public class ErwinPortalLdapStorageMapper implements LDAPStorageMapper {
+
+    public static List<ProviderConfigProperty> CONFIG_PROPERTIES;
+
+    private static final Logger LOGGER = Logger.getLogger(ErwinPortalLdapStorageMapper.class);
+
+    public static final String CONFIG_KEY_NEW_LDAP_USER_URL = "NEW_LDAP_USER_URL";
+    public static final String CONFIG_KEY_USERNAME_ATTR_NAME = "USERNAME_ATTR_NAME";
+    public static final String CONFIG_KEY_EMAIL_ATTR_NAME = "EMAIL_ATTR_NAME";
+    public static final String CONFIG_KEY_FIRSTNAME_ATTR_NAME = "FIRSTNAME_ATTR_NAME";
+    public static final String CONFIG_KEY_LASTNAME_ATTR_NAME = "LASTNAME_ATTR_NAME";
+
+    static {
+        CONFIG_PROPERTIES = ProviderConfigurationBuilder.create()
+                // Url to send a new user
+                .property()
+                .name(CONFIG_KEY_NEW_LDAP_USER_URL)
+                .label("New LDAP user url")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .required(true)
+                .add()
+
+                // LDAP attribute for the username
+                .property()
+                .name(CONFIG_KEY_USERNAME_ATTR_NAME)
+                .label("Username LDAP Attribute")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .defaultValue("uid")
+                .add()
+
+                // LDAP attribute for the email
+                .property()
+                .name(CONFIG_KEY_EMAIL_ATTR_NAME)
+                .label("Email LDAP Attribute")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .defaultValue("mail")
+                .add()
+
+                // LDAP attribute for the first name
+                .property()
+                .name(CONFIG_KEY_FIRSTNAME_ATTR_NAME)
+                .label("First name LDAP Attribute")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .defaultValue("givenName")
+                .add()
+
+                // LDAP attribute for the last name
+                .property()
+                .name(CONFIG_KEY_LASTNAME_ATTR_NAME)
+                .label("Last name LDAP Attribute")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .defaultValue("sn")
+                .add()
+
+                .build();
+    }
+
+    private final MultivaluedHashMap<String, String> config;
+
+    public ErwinPortalLdapStorageMapper(KeycloakSession session, ComponentModel model) {
+        this.config = model.getConfig();
+    }
+
+    @Override
+    public void onImportUserFromLDAP(LDAPObject ldapUser, UserModel user, RealmModel realm, boolean isCreate) {
+        final var url = config.getFirst(CONFIG_KEY_NEW_LDAP_USER_URL);
+        if (url == null) {
+            LOGGER.warnf("Config variable %s is not set or is empty.", CONFIG_KEY_NEW_LDAP_USER_URL);
+            return;
+        }
+
+        final var uri = URI.create(url);
+        final var keycloakUserId = user.getId();
+        final var userName = ldapUser.getAttributeAsString(config.getFirst(CONFIG_KEY_USERNAME_ATTR_NAME));
+        final var email = ldapUser.getAttributeAsString(config.getFirst(CONFIG_KEY_EMAIL_ATTR_NAME));
+        final var firstName = ldapUser.getAttributeAsString(config.getFirst(CONFIG_KEY_FIRSTNAME_ATTR_NAME));
+        final var lastName = ldapUser.getAttributeAsString(config.getFirst(CONFIG_KEY_LASTNAME_ATTR_NAME));
+        final var ldapDn = ldapUser.getDn().toString();
+        final var ldapId = ldapUser.getUuid();
+
+        try {
+            LdapUserRequestHelper.sendLdapUserData(uri, keycloakUserId, userName, email, firstName, lastName,
+                    ldapDn, ldapId);
+        } catch (final IOException e) {
+            LOGGER.error("IOException occurred while sending user to ErWIn-Portal", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    // empty implementations from abstract class. Not required for this plugin
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void onRegisterUserToLDAP(LDAPObject ldapUser, UserModel localUser, RealmModel realm) {
+
+    }
+
+    @Override
+    public LDAPStorageProvider getLdapProvider() {
+        return null;
+    }
+
+    @Override
+    public boolean onAuthenticationFailure(LDAPObject ldapUser, UserModel user, AuthenticationException ldapException,
+            RealmModel realm) {
+        return false;
+    }
+
+    @Override
+    public void beforeLDAPQuery(LDAPQuery query) {
+
+    }
+
+    @Override
+    public UserModel proxy(LDAPObject ldapUser, UserModel delegate, RealmModel realm) {
+        return delegate;
+    }
+
+    @Override
+    public List<UserModel> getRoleMembers(RealmModel realm, RoleModel role, int firstResult, int maxResults) {
+        return null;
+    }
+
+    @Override
+    public List<UserModel> getGroupMembers(RealmModel realm, GroupModel group, int firstResult, int maxResults) {
+        return null;
+    }
+
+    @Override
+    public SynchronizationResult syncDataFromFederationProviderToKeycloak(RealmModel realm) {
+        return new SynchronizationResult();
+    }
+
+    @Override
+    public SynchronizationResult syncDataFromKeycloakToFederationProvider(RealmModel realm) {
+        return new SynchronizationResult();
+    }
+
+    @Override
+    public Set<String> mandatoryAttributeNames() {
+        return null;
+    }
+
+    @Override
+    public Set<String> getUserAttributes() {
+        return Collections.emptySet();
+    }
+}

--- a/src/main/java/com/spsh/ldap/ErwinPortalLdapStorageMapperFactory.java
+++ b/src/main/java/com/spsh/ldap/ErwinPortalLdapStorageMapperFactory.java
@@ -1,0 +1,27 @@
+package com.spsh.ldap;
+
+import java.util.List;
+
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.storage.ldap.mappers.LDAPStorageMapperFactory;
+
+public class ErwinPortalLdapStorageMapperFactory implements LDAPStorageMapperFactory<ErwinPortalLdapStorageMapper> {
+
+    @Override
+    public ErwinPortalLdapStorageMapper create(KeycloakSession session, ComponentModel model) {
+        return new ErwinPortalLdapStorageMapper(session, model);
+    }
+
+    @Override
+    public String getId() {
+        return "erwin-portal-ldap-storage-mapper";
+    }
+    
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return ErwinPortalLdapStorageMapper.CONFIG_PROPERTIES;
+    }
+    
+}

--- a/src/main/java/com/spsh/ldap/LdapUserRequestHelper.java
+++ b/src/main/java/com/spsh/ldap/LdapUserRequestHelper.java
@@ -1,0 +1,51 @@
+package com.spsh.ldap;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+
+import org.json.JSONObject;
+
+import com.spsh.util.ApiFetchHelper;
+
+public final class LdapUserRequestHelper {
+
+    private LdapUserRequestHelper() {
+        throw new UnsupportedOperationException();
+    }
+    
+    public static void sendLdapUserData(URI uri, String keycloakUserId, String userName, String email,
+            String firstName,
+            String lastName, String ldapDn, String ldapId) throws IOException, InterruptedException {
+        final var apiKey = System.getenv(ApiFetchHelper.ENV_KEY_INTERNAL_COMMUNICATION_API_KEY);
+        if (apiKey == null || apiKey.isEmpty()) {
+            throw new IOException(String.format("Environment variable %s is not set or is empty.",
+                    ApiFetchHelper.ENV_KEY_INTERNAL_COMMUNICATION_API_KEY));
+        }
+
+        final var json = new JSONObject();
+        json.put("keycloakUserId", keycloakUserId);
+        json.put("userName", userName);
+        json.put("email", email);
+        json.put("firstName", firstName);
+        json.put("lastName", lastName);
+        json.put("ldapDn", ldapDn);
+        json.put("ldapId", ldapId);
+
+        final var request = HttpRequest.newBuilder(uri)
+                .POST(BodyPublishers.ofString(json.toString()))
+                .header("api-key", apiKey)
+                .header("Content-Type", "application/json")
+                .build();
+
+        final var result = HttpClient.newHttpClient().send(request, BodyHandlers.discarding());
+        final var statusCode = result.statusCode();
+
+        if (statusCode != 201) {
+            throw new IOException("Unexpected response status: " + statusCode);
+        }
+    }
+}

--- a/src/main/java/com/spsh/oidc/OriginalSpshApiOidcMapper.java
+++ b/src/main/java/com/spsh/oidc/OriginalSpshApiOidcMapper.java
@@ -1,0 +1,139 @@
+package com.spsh.oidc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+import org.keycloak.protocol.oidc.mappers.OIDCIDTokenMapper;
+import org.keycloak.protocol.oidc.mappers.UserInfoTokenMapper;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.IDToken;
+
+import com.spsh.util.OriginalApiFetchHelper;
+
+import jakarta.ws.rs.InternalServerErrorException;
+
+public class OriginalSpshApiOidcMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper {
+
+
+    public static final String ENV_KEY_INTERNAL_COMMUNICATION_API_KEY = "INTERNAL_COMMUNICATION_API_KEY";
+    public static final String PROVIDER_ID = "original-spsh-custom-oidc-api-mapper";
+    public static final String FETCH_URL = "fetchUrl";
+    public static final String EXTRACT_JSON_PATH = "extractJsonPath";
+    public static final String IGNORE_MISSING_PATH = "ignoreMissingPath";
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+    private static final Logger LOGGER = Logger.getLogger(SpshApiOidcMapper.class);
+
+    static {
+        OIDCAttributeMapperHelper.addTokenClaimNameConfig(configProperties);
+        OIDCAttributeMapperHelper.addIncludeInTokensConfig(configProperties, SpshApiOidcMapper.class);
+
+        ProviderConfigProperty multivaluedProperty = new ProviderConfigProperty();
+        multivaluedProperty.setName(ProtocolMapperUtils.MULTIVALUED);
+        multivaluedProperty.setLabel(ProtocolMapperUtils.MULTIVALUED_LABEL);
+        multivaluedProperty.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        multivaluedProperty.setHelpText(ProtocolMapperUtils.MULTIVALUED_HELP_TEXT);
+        configProperties.add(multivaluedProperty);
+
+        ProviderConfigProperty fetchUrlProperty = new ProviderConfigProperty();
+        fetchUrlProperty.setName(FETCH_URL);
+        fetchUrlProperty.setLabel("SPSH Fetch Url");
+        fetchUrlProperty.setType(ProviderConfigProperty.STRING_TYPE);
+        fetchUrlProperty.setHelpText("The URL to fetch data from the SPSH Backend.");
+        configProperties.add(fetchUrlProperty);
+
+        ProviderConfigProperty extractPathProperty = new ProviderConfigProperty();
+        extractPathProperty.setName(EXTRACT_JSON_PATH);
+        extractPathProperty.setLabel("SPSH Extract Json Path");
+        extractPathProperty.setType(ProviderConfigProperty.STRING_TYPE);
+        extractPathProperty.setHelpText("The JSON path to extract data from the API response.");
+        configProperties.add(extractPathProperty);
+
+        ProviderConfigProperty ignoreMissingPathProperty = new ProviderConfigProperty();
+        ignoreMissingPathProperty.setName(IGNORE_MISSING_PATH);
+        ignoreMissingPathProperty.setLabel("SPSH Ignore Missing Path");
+        ignoreMissingPathProperty.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        ignoreMissingPathProperty.setHelpText("If JSON Path cannot be found in response received from Backend, do not throw an error, just ignore it.");
+        configProperties.add(ignoreMissingPathProperty);
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return "Token Mapper";
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "SPSH Custom OIDC Api Mapper";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "The mapper calls the provided SPSH fetch url, extracts the provided JsonPath from the api response and maps the result if not null to the claim";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    protected void setClaim(IDToken token, ProtocolMapperModel mappingModel,
+                            UserSessionModel userSession, KeycloakSession keycloakSession,
+                            ClientSessionContext clientSessionCtx) {
+        String fetchUrl = mappingModel.getConfig().get(FETCH_URL);
+        String extractJsonPath = mappingModel.getConfig().get(EXTRACT_JSON_PATH);
+        boolean ignoreMissingPath = Boolean.parseBoolean(mappingModel.getConfig().getOrDefault(IGNORE_MISSING_PATH, "false"));
+        String userSub = userSession.getUser().getId();
+
+        LOGGER.info(String.format("Setting claims via custom SpshApiOidcMapper for userSub: %s", userSub));
+        LOGGER.debug(String.format("Using fetchUrl: %s", fetchUrl));
+        LOGGER.debug(String.format("Using extractJsonPath: %s", extractJsonPath));
+        LOGGER.debug(String.format("Using userSub: %s", userSub));
+
+        if (fetchUrl == null) {
+            LOGGER.warn("SpshApiOidcMapper: fetchUrl is null. No data will be fetched, extracted and mapped.");
+            return;
+        }
+        if (extractJsonPath == null) {
+            LOGGER.warn("SpshApiOidcMapper: extractJsonPath is null. No data will be fetched, extracted and mapped.");
+            return;
+        }
+        if (userSub == null) {
+            LOGGER.warn("SpshApiOidcMapper: userSub is null. No data will be fetched, extracted and mapped.");
+            return;
+        }
+
+        try {
+            String responseData = OriginalApiFetchHelper.fetchApiData(fetchUrl, userSub);
+            boolean isExisting = OriginalApiFetchHelper.isPathExisting(responseData, extractJsonPath);
+            if(!isExisting && ignoreMissingPath) {
+                LOGGER.info(String.format("Ignoring due to configuration that JSON Path %s does not exist in response", extractJsonPath));
+                return;
+            }
+            if(!isExisting && !ignoreMissingPath) {
+                throw new InternalServerErrorException(String.format("JSON Path %s does not exist in response: %s", extractJsonPath, responseData));
+            }
+            Object extractedValue = OriginalApiFetchHelper.extractFromJson(responseData, extractJsonPath);
+            if (extractedValue != null) {
+                OIDCAttributeMapperHelper.mapClaim(token, mappingModel, extractedValue);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+}

--- a/src/main/java/com/spsh/oidc/SpshApiOidcMapper.java
+++ b/src/main/java/com/spsh/oidc/SpshApiOidcMapper.java
@@ -1,14 +1,14 @@
 package com.spsh.oidc;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
+import com.spsh.oidc.dto.FetchUrlResponse;
+import com.spsh.util.JsonHelper;
+import jakarta.ws.rs.NotFoundException;
 import org.jboss.logging.Logger;
-import org.keycloak.models.ClientSessionContext;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.ProtocolMapperModel;
-import org.keycloak.models.UserSessionModel;
-import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.models.*;
 import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
 import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenMapper;
 import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
@@ -21,6 +21,12 @@ import com.spsh.util.ApiFetchHelper;
 
 import jakarta.ws.rs.InternalServerErrorException;
 
+import static java.lang.Integer.parseInt;
+import static org.keycloak.protocol.ProtocolMapperUtils.MULTIVALUED;
+import static org.keycloak.protocol.ProtocolMapperUtils.MULTIVALUED_LABEL;
+import static org.keycloak.protocol.ProtocolMapperUtils.MULTIVALUED_HELP_TEXT;
+
+
 public class SpshApiOidcMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper {
 
 
@@ -32,15 +38,22 @@ public class SpshApiOidcMapper extends AbstractOIDCProtocolMapper implements OID
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
     private static final Logger LOGGER = Logger.getLogger(SpshApiOidcMapper.class);
 
+
+    public static final String TIMEOUT_MS = "timeoutMs";
+    public static final String CACHE_TTL_SECONDS = "cacheTtlSeconds";
+    public static final String FAIL_MODE = "failMode";
+    public static final String AUTH_HEADER_NAME = "authHeaderName";
+
     static {
         OIDCAttributeMapperHelper.addTokenClaimNameConfig(configProperties);
         OIDCAttributeMapperHelper.addIncludeInTokensConfig(configProperties, SpshApiOidcMapper.class);
+        OIDCAttributeMapperHelper.addJsonTypeConfig(configProperties);
 
         ProviderConfigProperty multivaluedProperty = new ProviderConfigProperty();
-        multivaluedProperty.setName(ProtocolMapperUtils.MULTIVALUED);
-        multivaluedProperty.setLabel(ProtocolMapperUtils.MULTIVALUED_LABEL);
+        multivaluedProperty.setName(MULTIVALUED);
+        multivaluedProperty.setLabel(MULTIVALUED_LABEL);
         multivaluedProperty.setType(ProviderConfigProperty.BOOLEAN_TYPE);
-        multivaluedProperty.setHelpText(ProtocolMapperUtils.MULTIVALUED_HELP_TEXT);
+        multivaluedProperty.setHelpText(MULTIVALUED_HELP_TEXT);
         configProperties.add(multivaluedProperty);
 
         ProviderConfigProperty fetchUrlProperty = new ProviderConfigProperty();
@@ -63,6 +76,8 @@ public class SpshApiOidcMapper extends AbstractOIDCProtocolMapper implements OID
         ignoreMissingPathProperty.setType(ProviderConfigProperty.BOOLEAN_TYPE);
         ignoreMissingPathProperty.setHelpText("If JSON Path cannot be found in response received from Backend, do not throw an error, just ignore it.");
         configProperties.add(ignoreMissingPathProperty);
+
+
     }
 
     @Override
@@ -72,12 +87,12 @@ public class SpshApiOidcMapper extends AbstractOIDCProtocolMapper implements OID
 
     @Override
     public String getDisplayType() {
-        return "SPSH Custom OIDC Api Mapper";
+        return "ErWIn Custom OIDC Api Mapper";
     }
 
     @Override
     public String getHelpText() {
-        return "The mapper calls the provided SPSH fetch url, extracts the provided JsonPath from the api response and maps the result if not null to the claim";
+        return "The mapper calls the provided ErWIn-Portal fetch url, extracts the provided JsonPath from the api response and maps the result if not null to the claim";
     }
 
     @Override
@@ -91,49 +106,161 @@ public class SpshApiOidcMapper extends AbstractOIDCProtocolMapper implements OID
     }
 
     @Override
-    protected void setClaim(IDToken token, ProtocolMapperModel mappingModel,
-      UserSessionModel userSession, KeycloakSession keycloakSession,
-      ClientSessionContext clientSessionCtx) {
-        String fetchUrl = mappingModel.getConfig().get(FETCH_URL);
-        String extractJsonPath = mappingModel.getConfig().get(EXTRACT_JSON_PATH);
-        boolean ignoreMissingPath = Boolean.parseBoolean(mappingModel.getConfig().getOrDefault(IGNORE_MISSING_PATH, "false"));
-        String userSub = userSession.getUser().getId();
+    protected void setClaim(IDToken token,
+                            ProtocolMapperModel mappingModel,
+                            UserSessionModel userSession,
+                            KeycloakSession keycloakSession,
+                            ClientSessionContext clientSessionCtx) throws IllegalArgumentException, NotFoundException {
 
-        LOGGER.info(String.format("Setting claims via custom SpshApiOidcMapper for userSub: %s", userSub));
+        final Map<String, String> config = mappingModel.getConfig();
+
+        final String fetchUrl        = config.get(FETCH_URL);
+        final String jsonPath        = config.get(EXTRACT_JSON_PATH);
+        final boolean ignoreMissing  = Boolean.parseBoolean(config.getOrDefault(IGNORE_MISSING_PATH, "false"));
+        final boolean multivalued    = Boolean.parseBoolean(config.getOrDefault(MULTIVALUED, "false"));
+        final String  failMode       = config.getOrDefault(FAIL_MODE, "deny");
+        final int     timeoutMs      = parseInt(config.getOrDefault(TIMEOUT_MS, "1500"));
+        final int     cacheTtlSec    = parseInt(config.getOrDefault(CACHE_TTL_SECONDS, "60"));
+        final String  headerName     = config.getOrDefault(AUTH_HEADER_NAME, "api-key");
+        final UserModel user = (userSession != null) ? userSession.getUser() : null;
+
+        if (user == null) return;
+
+        final String userId = user.getId();
+
+        LOGGER.info(String.format("Setting claims via custom SpshApiOidcMapper for userSub: %s", userId));
         LOGGER.debug(String.format("Using fetchUrl: %s", fetchUrl));
-        LOGGER.debug(String.format("Using extractJsonPath: %s", extractJsonPath));
-        LOGGER.debug(String.format("Using userSub: %s", userSub));
+        LOGGER.debug(String.format("Using user with the following userId: %s", userId));
 
         if (fetchUrl == null) {
             LOGGER.warn("SpshApiOidcMapper: fetchUrl is null. No data will be fetched, extracted and mapped.");
-            return;
+            throw new NotFoundException("SpshApiOidcMapper: fetchUrl is null. No data will be fetched, extracted and mapped.");
         }
-        if (extractJsonPath == null) {
-            LOGGER.warn("SpshApiOidcMapper: extractJsonPath is null. No data will be fetched, extracted and mapped.");
-            return;
+        if (jsonPath == null) {
+            LOGGER.warn("SpshApiOidcMapper: jsonPath is null. No data will be fetched, extracted and mapped.");
+            throw new NotFoundException("SpshApiOidcMapper: jsonPath is null. No data will be fetched, extracted and mapped.");
         }
-        if (userSub == null) {
-            LOGGER.warn("SpshApiOidcMapper: userSub is null. No data will be fetched, extracted and mapped.");
-            return;
+        if (userId == null) {
+            LOGGER.warn("SpshApiOidcMapper: userId is null. No data will be fetched, extracted and mapped.");
+            throw new NotFoundException("SpshApiOidcMapper: userId is null. No data will be fetched, extracted and mapped.");
         }
+
+        final var kcClientSession = clientSessionCtx.getClientSession();
+        final var clientModel     = kcClientSession.getClient();
+        final String clientName         = clientModel.getName();
+
+        if (isBlank(clientName)) {
+         LOGGER.warn("client name does not exist, throwing error...");
+         throw new IllegalArgumentException("Client name does not exist");
+        }
+
+        final String cacheValKey = "spsh_mapper_cache_value_" + mappingModel.getId();
+        final String cacheTsKey  = "spsh_mapper_cache_ts_" + mappingModel.getId();
 
         try {
-            String responseData = ApiFetchHelper.fetchApiData(fetchUrl, userSub);
-            boolean isExisting = ApiFetchHelper.isPathExisting(responseData, extractJsonPath);
-            if(!isExisting && ignoreMissingPath) {
-                LOGGER.info(String.format("Ignoring due to configuration that JSON Path %s does not exist in response", extractJsonPath));
-                return;
+            LOGGER.debug("retrieving info from cache if valid");
+            String cached = userSession.getNote(cacheValKey);
+            String ts = userSession.getNote(cacheTsKey);
+            long now = System.currentTimeMillis();
+            if (cached != null && ts != null) {
+                try {
+                    LOGGER.debug("cache found, testing validity...");
+                    long fetchedAt = Long.parseLong(ts);
+                    if ((now - fetchedAt) <= cacheTtlSec * 1000L) {
+                        LOGGER.debug("cache valid, extracting response...");
+                        FetchUrlResponse response = extractValueOrHandleMissing(cached, jsonPath, ignoreMissing, failMode);
+                        if (response != null || ignoreMissing) {
+                            LOGGER.debug("response successfully extracted, on to mapping...");
+                            assignRoleToUser(user, clientSessionCtx, response);
+                            mapValue(token, mappingModel, response);
+                            LOGGER.debug("response successfully mapped, exiting");
+                            return;
+                        }
+                    }
+                } catch (Exception e) {
+                    LOGGER.debug("Cache parse/expiry failed; fetching fresh.", e);
+                    throw new Exception(e);
+                }
             }
-            if(!isExisting && !ignoreMissingPath) {
-                throw new InternalServerErrorException(String.format("JSON Path %s does not exist in response: %s", extractJsonPath, responseData));
+
+            String json = ApiFetchHelper.fetchApiData(
+                    fetchUrl, userId, clientName, headerName, timeoutMs
+            );
+            FetchUrlResponse response = extractValueOrHandleMissing(json, jsonPath, ignoreMissing, failMode);
+
+            if (response == null && ignoreMissing) {
+                LOGGER.debug("no items found in the fetchUrlResponse, exiting");
+                throw new NotFoundException("Client name does not exist");
             }
-            Object extractedValue = ApiFetchHelper.extractFromJson(responseData, extractJsonPath);
-            if (extractedValue != null) {
-                OIDCAttributeMapperHelper.mapClaim(token, mappingModel, extractedValue);
+            assignRoleToUser(user, clientSessionCtx, response);
+            mapValue(token, mappingModel, response);
+
+            try {
+                userSession.setNote(cacheValKey, json);
+                userSession.setNote(cacheTsKey, Long.toString(System.currentTimeMillis()));
+            } catch (Exception e) {
+                LOGGER.debug("Failed to write session cache.", e);
             }
+
         } catch (Exception e) {
-            e.printStackTrace();
+            if ("deny".equalsIgnoreCase(failMode)) {
+                LOGGER.error("SpshApiOidcMapper: backend fetch/mapping failed; denying token issuance.", e);
+                throw (e instanceof InternalServerErrorException)
+                        ? (InternalServerErrorException) e
+                        : new InternalServerErrorException("SpshApiOidcMapper failed", e);
+            } else {
+                LOGGER.warn("SpshApiOidcMapper: backend fetch/mapping failed; skipping claim per failMode=allowNoClaim.", e);
+            }
+        }
+    }
+
+    /* Helper classes for data manipulation */
+
+    private static boolean isBlank(String s) { return s == null || s.isBlank(); }
+
+    private static FetchUrlResponse extractValueOrHandleMissing(String json, String jsonPath, boolean ignoreMissing, String failMode) {
+        boolean exists = JsonHelper.isPathExisting(json, jsonPath);
+        if (!exists) {
+            if (ignoreMissing) return null;
+            if ("deny".equalsIgnoreCase(failMode)) {
+                throw new InternalServerErrorException("JSONPath " + jsonPath + " not found in backend response.");
+            }
+            LOGGER.warnf("JSONPath %s not found; skipping per failMode=allowNoClaim.", jsonPath);
+            return null;
+        }
+        FetchUrlResponse jsonValue = JsonHelper.extractFromJson(json);
+        if (jsonValue == null) {
+            LOGGER.warn("extracted FetchURL response is null");
+        }
+        return jsonValue;
+    }
+
+    private static void mapValue(IDToken token, ProtocolMapperModel model, FetchUrlResponse response) {
+        if (response == null) return;
+
+        OIDCAttributeMapperHelper.mapClaim(token, model, response);
+    }
+
+    private static void assignRoleToUser(UserModel user,
+                                         ClientSessionContext clientCtx,
+                                         FetchUrlResponse response) {
+        if (response == null) return;
+
+        String roleName = response.getMapToLmsRolle().trim();
+        if (roleName.isEmpty()) return;
+
+        ClientModel client = clientCtx.getClientSession().getClient();
+        RoleModel role = client.getRole(roleName);
+
+        if (role == null) {
+            LOGGER.warnf("Role '%s' not found in client '%s'; skipping.", roleName, client.getClientId());
+            return;
         }
 
+        if (!user.hasRole(role)) {
+            user.grantRole(role);
+            LOGGER.infof("Granted role '%s' to user '%s'.", roleName, user.getUsername());
+        }
     }
+
 }

--- a/src/main/java/com/spsh/oidc/dto/FetchUrlResponse.java
+++ b/src/main/java/com/spsh/oidc/dto/FetchUrlResponse.java
@@ -1,0 +1,22 @@
+package com.spsh.oidc.dto;
+
+public class FetchUrlResponse {
+    private String mapToLmsRolle;
+    private String userId;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getMapToLmsRolle() {
+        return mapToLmsRolle;
+    }
+
+    public void setMapToLmsRolle(String mapToLmsRolle) {
+        this.mapToLmsRolle = mapToLmsRolle;
+    }
+}

--- a/src/main/java/com/spsh/saml/SpshApiSamlMapper.java
+++ b/src/main/java/com/spsh/saml/SpshApiSamlMapper.java
@@ -3,6 +3,7 @@ package com.spsh.saml;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.spsh.util.JsonHelper;
 import org.jboss.logging.Logger;
 import org.keycloak.dom.saml.v2.assertion.AttributeStatementType;
 import org.keycloak.dom.saml.v2.assertion.AttributeStatementType.ASTChoiceType;
@@ -95,7 +96,7 @@ public class SpshApiSamlMapper extends AbstractSAMLProtocolMapper implements SAM
 
         try {
             String responseData = ApiFetchHelper.fetchApiData(fetchUrl, userSub);
-            Object extractedValue = ApiFetchHelper.extractFromJson(responseData, extractJsonPath);
+            Object extractedValue = JsonHelper.extractFromJson(responseData);
             if (extractedValue != null) {
                 AttributeType samlAttribute = new AttributeType(mappingModel.getName());
                 samlAttribute.addAttributeValue(extractedValue);

--- a/src/main/java/com/spsh/util/ApiFetchHelper.java
+++ b/src/main/java/com/spsh/util/ApiFetchHelper.java
@@ -2,10 +2,7 @@ package com.spsh.util;
 
 import java.io.IOException;
 
-import com.spsh.oidc.SpshApiOidcMapper;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
-// (GET import kept only if you need it later)
-// import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -15,18 +12,17 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 
 import org.apache.hc.core5.util.Timeout;
-import org.jboss.logging.Logger;
 
 public class ApiFetchHelper {
 
     public static final String ENV_KEY_INTERNAL_COMMUNICATION_API_KEY = "INTERNAL_COMMUNICATION_API_KEY";
-    private static final Logger LOGGER = Logger.getLogger(ApiFetchHelper.class);
 
     public static String fetchApiData(String url, String userSub) throws IOException {
 
         String apiKey = System.getenv(ENV_KEY_INTERNAL_COMMUNICATION_API_KEY);
         if (apiKey == null || apiKey.isEmpty()) {
-            throw new IOException(String.format("Environment variable %s is not set or is empty.", ENV_KEY_INTERNAL_COMMUNICATION_API_KEY));
+            throw new IOException(String.format("Environment variable %s is not set or is empty.",
+                    ENV_KEY_INTERNAL_COMMUNICATION_API_KEY));
         }
 
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
@@ -49,14 +45,15 @@ public class ApiFetchHelper {
     }
 
     public static String fetchApiData(String url,
-                                      String userId,
-                                      String clientName,
-                                      String headerName,
-                                      int timeoutMs) throws IOException {
+            String userId,
+            String clientName,
+            String headerName,
+            int timeoutMs) throws IOException {
 
         String apiKey = System.getenv(ENV_KEY_INTERNAL_COMMUNICATION_API_KEY);
         if (apiKey == null || apiKey.isEmpty()) {
-            throw new IOException(String.format("Environment variable %s is not set or is empty.", ENV_KEY_INTERNAL_COMMUNICATION_API_KEY));
+            throw new IOException(String.format("Environment variable %s is not set or is empty.",
+                    ENV_KEY_INTERNAL_COMMUNICATION_API_KEY));
         }
 
         String header = (headerName == null || headerName.isBlank()) ? "api-key" : headerName;
@@ -66,8 +63,7 @@ public class ApiFetchHelper {
                 .setResponseTimeout(Timeout.ofMilliseconds(timeoutMs))
                 .build();
 
-        try (CloseableHttpClient httpClient =
-                     HttpClients.custom().setDefaultRequestConfig(requestConfig).build()) {
+        try (CloseableHttpClient httpClient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build()) {
 
             HttpPost request = new HttpPost(url);
             request.setHeader("Content-Type", "application/json");

--- a/src/main/java/com/spsh/util/ApiFetchHelper.java
+++ b/src/main/java/com/spsh/util/ApiFetchHelper.java
@@ -2,18 +2,25 @@ package com.spsh.util;
 
 import java.io.IOException;
 
+import com.spsh.oidc.SpshApiOidcMapper;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
+// (GET import kept only if you need it later)
+// import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 
-import com.jayway.jsonpath.JsonPath;
+import org.apache.hc.core5.util.Timeout;
+import org.jboss.logging.Logger;
 
 public class ApiFetchHelper {
 
     public static final String ENV_KEY_INTERNAL_COMMUNICATION_API_KEY = "INTERNAL_COMMUNICATION_API_KEY";
+    private static final Logger LOGGER = Logger.getLogger(ApiFetchHelper.class);
 
     public static String fetchApiData(String url, String userSub) throws IOException {
 
@@ -41,17 +48,47 @@ public class ApiFetchHelper {
         }
     }
 
-    public static boolean isPathExisting(String jsonData, String jsonPath) {
-        try{
-            JsonPath.read(jsonData, jsonPath);
-            return true;
-        } catch(com.jayway.jsonpath.PathNotFoundException e) {
-            return false;
+    public static String fetchApiData(String url,
+                                      String userId,
+                                      String clientName,
+                                      String headerName,
+                                      int timeoutMs) throws IOException {
+
+        String apiKey = System.getenv(ENV_KEY_INTERNAL_COMMUNICATION_API_KEY);
+        if (apiKey == null || apiKey.isEmpty()) {
+            throw new IOException(String.format("Environment variable %s is not set or is empty.", ENV_KEY_INTERNAL_COMMUNICATION_API_KEY));
+        }
+
+        String header = (headerName == null || headerName.isBlank()) ? "api-key" : headerName;
+
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(Timeout.ofMilliseconds(timeoutMs))
+                .setResponseTimeout(Timeout.ofMilliseconds(timeoutMs))
+                .build();
+
+        try (CloseableHttpClient httpClient =
+                     HttpClients.custom().setDefaultRequestConfig(requestConfig).build()) {
+
+            HttpPost request = new HttpPost(url);
+            request.setHeader("Content-Type", "application/json");
+            request.setHeader(header, apiKey);
+
+            String payload = "{"
+                    + "\"userId\":" + JsonHelper.jsonString(userId) + ","
+                    + "\"clientName\":" + JsonHelper.jsonString(clientName)
+                    + "}";
+
+            request.setEntity(new StringEntity(payload));
+
+            return httpClient.execute(request, response -> {
+                int statusCode = response.getCode();
+                if (statusCode >= 200 && statusCode < 300) {
+                    HttpEntity entity = response.getEntity();
+                    return entity != null ? EntityUtils.toString(entity) : null;
+                } else {
+                    throw new IOException("Unexpected response status: " + statusCode);
+                }
+            });
         }
     }
-
-    public static Object extractFromJson(String jsonData, String jsonPath) {
-        return JsonPath.read(jsonData, jsonPath);
-    }
 }
-

--- a/src/main/java/com/spsh/util/JsonHelper.java
+++ b/src/main/java/com/spsh/util/JsonHelper.java
@@ -1,0 +1,40 @@
+package com.spsh.util;
+
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
+import com.spsh.oidc.dto.FetchUrlResponse;
+
+public class JsonHelper {
+
+    /** True if the JSONPath exists (value not null). */
+    public static boolean isPathExisting(String jsonData, String jsonPath) {
+        try {
+            JsonPath.read(jsonData, jsonPath);
+            return true;
+        } catch (PathNotFoundException e) {
+            return false;
+        }
+    }
+
+    /** Extract value at JSONPath */
+    public static FetchUrlResponse extractFromJson(String jsonData) {
+        FetchUrlResponse extractedResponse  = new FetchUrlResponse();
+        extractedResponse.setUserId(JsonPath.read(jsonData, "$.userId"));
+        extractedResponse.setMapToLmsRolle(JsonPath.read(jsonData, "$.mapToLmsRolle"));
+
+        if(!extractedResponse.getUserId().isEmpty() || !extractedResponse.getMapToLmsRolle().isEmpty())
+        {
+            return extractedResponse;
+        }
+        else {
+
+            return null;
+        }
+    }
+
+    /** Helper for JSON Escaping */
+    public static String jsonString(String s) {
+        if (s == null) return "null";
+        return "\"" + s.replace("\\","\\\\").replace("\"","\\\"") + "\"";
+    }
+}

--- a/src/main/java/com/spsh/util/OriginalApiFetchHelper.java
+++ b/src/main/java/com/spsh/util/OriginalApiFetchHelper.java
@@ -1,0 +1,57 @@
+package com.spsh.util;
+
+import java.io.IOException;
+
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+
+import com.jayway.jsonpath.JsonPath;
+
+public class OriginalApiFetchHelper {
+
+    public static final String ENV_KEY_INTERNAL_COMMUNICATION_API_KEY = "INTERNAL_COMMUNICATION_API_KEY";
+
+    public static String fetchApiData(String url, String userSub) throws IOException {
+
+        String apiKey = System.getenv(ENV_KEY_INTERNAL_COMMUNICATION_API_KEY);
+        if (apiKey == null || apiKey.isEmpty()) {
+            throw new IOException(String.format("Environment variable %s is not set or is empty.", ENV_KEY_INTERNAL_COMMUNICATION_API_KEY));
+        }
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpPost request = new HttpPost(url);
+            request.setHeader("Content-Type", "application/json");
+            request.setHeader("api-key", apiKey);
+            StringEntity requestBody = new StringEntity(String.format("{\"sub\":\"%s\"}", userSub));
+            request.setEntity(requestBody);
+
+            return httpClient.execute(request, response -> {
+                int statusCode = response.getCode();
+                if (statusCode >= 200 && statusCode < 300) {
+                    HttpEntity entity = response.getEntity();
+                    return entity != null ? EntityUtils.toString(entity) : null;
+                } else {
+                    throw new IOException("Unexpected response status: " + statusCode);
+                }
+            });
+        }
+    }
+
+    public static boolean isPathExisting(String jsonData, String jsonPath) {
+        try{
+            JsonPath.read(jsonData, jsonPath);
+            return true;
+        } catch(com.jayway.jsonpath.PathNotFoundException e) {
+            return false;
+        }
+    }
+
+    public static Object extractFromJson(String jsonData, String jsonPath) {
+        return JsonPath.read(jsonData, jsonPath);
+    }
+}
+

--- a/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -1,2 +1,3 @@
 com.spsh.oidc.SpshApiOidcMapper
 com.spsh.saml.SpshApiSamlMapper
+com.spsh.oidc.OriginalSpshApiOidcMapper

--- a/src/main/resources/META-INF/services/org.keycloak.storage.ldap.mappers.LDAPStorageMapperFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.storage.ldap.mappers.LDAPStorageMapperFactory
@@ -1,0 +1,1 @@
+com.spsh.ldap.ErwinPortalLdapStorageMapperFactory

--- a/src/test/java/com/spsh/oidc/SpshApiOidcMapperTest.java
+++ b/src/test/java/com/spsh/oidc/SpshApiOidcMapperTest.java
@@ -1,0 +1,377 @@
+package com.spsh.oidc;
+
+import com.spsh.oidc.dto.FetchUrlResponse;
+import com.spsh.util.ApiFetchHelper;
+import com.spsh.util.JsonHelper;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.keycloak.models.*;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.IDToken;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.spsh.oidc.SpshApiOidcMapper.*;
+import static org.junit.Assert.*;
+import static org.keycloak.protocol.ProtocolMapperUtils.MULTIVALUED;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SpshApiOidcMapperTest {
+
+    // expose protected setClaim
+    static class TestableSpshApiOidcMapper extends SpshApiOidcMapper {
+        public void callSetClaim(IDToken token,
+                                 ProtocolMapperModel mappingModel,
+                                 UserSessionModel userSession,
+                                 KeycloakSession keycloakSession,
+                                 ClientSessionContext clientSessionCtx) {
+            super.setClaim(token, mappingModel, userSession, keycloakSession, clientSessionCtx);
+        }
+    }
+
+    private final TestableSpshApiOidcMapper mapper = new TestableSpshApiOidcMapper();
+
+    @Mock
+    ProtocolMapperModel mappingModel;
+    @Mock
+    UserSessionModel userSession;
+    @Mock
+    KeycloakSession keycloakSession;
+    @Mock
+    ClientSessionContext clientSessionCtx;
+    @Mock
+    AuthenticatedClientSessionModel clientSession;
+    @Mock
+    ClientModel clientModel;
+    @Mock
+    UserModel user;
+    @Mock
+    RoleModel roleModel;
+    @Mock
+    FetchUrlResponse fetchUrlResponse;
+
+    private Map<String, String> baseConfig() {
+        Map<String, String> config = new HashMap<>();
+        config.put(FETCH_URL, "https://example.com/api");
+        config.put(EXTRACT_JSON_PATH, "$.path");
+        config.put(IGNORE_MISSING_PATH, "false");
+        config.put(MULTIVALUED, "false");
+        config.put(FAIL_MODE, "deny");
+        config.put(TIMEOUT_MS, "1500");
+        config.put(CACHE_TTL_SECONDS, "60");
+        config.put(AUTH_HEADER_NAME, "api-key");
+        return config;
+    }
+
+    private void setupCommonMocks(Map<String, String> config) {
+        when(mappingModel.getConfig()).thenReturn(config);
+        when(mappingModel.getId()).thenReturn("mapper-id");
+
+        when(userSession.getUser()).thenReturn(user);
+        when(user.getId()).thenReturn("user-123");
+        when(user.getUsername()).thenReturn("john");
+
+        when(clientSessionCtx.getClientSession()).thenReturn(clientSession);
+        when(clientSession.getClient()).thenReturn(clientModel);
+        when(clientModel.getName()).thenReturn("test-client");
+        when(clientModel.getClientId()).thenReturn("test-client-id");
+    }
+
+    @Test
+    public void getDisplayCategory_returnsTokenMapper() {
+        assertEquals("Token Mapper", mapper.getDisplayCategory());
+    }
+
+    @Test
+    public void getDisplayType_returnsCustomDisplay() {
+        assertEquals("ErWIn Custom OIDC Api Mapper", mapper.getDisplayType());
+    }
+
+    @Test
+    public void getHelpText_notNull() {
+        assertNotNull(mapper.getHelpText());
+    }
+
+    @Test
+    public void getId_returnsProviderId() {
+        assertEquals(PROVIDER_ID, mapper.getId());
+    }
+
+    @Test
+    public void getConfigProperties_notEmpty() {
+        List<ProviderConfigProperty> props = mapper.getConfigProperties();
+        assertFalse(props.isEmpty());
+    }
+
+    @Test
+    public void setClaim_userNull_doesNothing() {
+        Map<String, String> config = baseConfig();
+        when(mappingModel.getConfig()).thenReturn(config);
+        when(userSession.getUser()).thenReturn(null);
+
+        mapper.callSetClaim(new IDToken(), mappingModel, userSession, keycloakSession, clientSessionCtx);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void setClaim_fetchUrlNull_throwsNotFoundException() {
+        Map<String, String> config = baseConfig();
+        config.remove(FETCH_URL);
+        setupCommonMocks(config);
+
+        mapper.callSetClaim(new IDToken(), mappingModel, userSession, keycloakSession, clientSessionCtx);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void setClaim_jsonPathNull_throwsNotFoundException() {
+        Map<String, String> config = baseConfig();
+        config.remove(EXTRACT_JSON_PATH);
+        setupCommonMocks(config);
+
+        mapper.callSetClaim(new IDToken(), mappingModel, userSession, keycloakSession, clientSessionCtx);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void setClaim_userIdNull_throwsNotFoundException() {
+        Map<String, String> config = baseConfig();
+        setupCommonMocks(config);
+        when(user.getId()).thenReturn(null);
+
+        mapper.callSetClaim(new IDToken(), mappingModel, userSession, keycloakSession, clientSessionCtx);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setClaim_clientNameBlank_throwsIllegalArgumentException() {
+        Map<String, String> config = baseConfig();
+        setupCommonMocks(config);
+        when(clientModel.getName()).thenReturn("   ");
+
+        mapper.callSetClaim(new IDToken(), mappingModel, userSession, keycloakSession, clientSessionCtx);
+    }
+
+    @Test
+    public void setClaim_validCache_usesCachedNoBackendCall() {
+        Map<String, String> config = baseConfig();
+        setupCommonMocks(config);
+
+        when(userSession.getNote("spsh_mapper_cache_value_mapper-id"))
+                .thenReturn("{\"some\":\"json\"}");
+        when(userSession.getNote("spsh_mapper_cache_ts_mapper-id"))
+                .thenReturn(Long.toString(System.currentTimeMillis()));
+
+        try (MockedStatic<JsonHelper> jsonHelperMock = mockStatic(JsonHelper.class);
+             MockedStatic<ApiFetchHelper> apiFetchMock = mockStatic(ApiFetchHelper.class);
+             MockedStatic<OIDCAttributeMapperHelper> oidcMapperMock = mockStatic(OIDCAttributeMapperHelper.class)) {
+
+            jsonHelperMock.when(() -> JsonHelper.isPathExisting(anyString(), anyString()))
+                    .thenReturn(true);
+            jsonHelperMock.when(() -> JsonHelper.extractFromJson(anyString()))
+                    .thenReturn(fetchUrlResponse);
+            when(fetchUrlResponse.getMapToLmsRolle()).thenReturn("role-1");
+            when(clientModel.getRole("role-1")).thenReturn(roleModel);
+            when(user.hasRole(roleModel)).thenReturn(false);
+
+            IDToken token = new IDToken();
+
+            mapper.callSetClaim(token, mappingModel, userSession, keycloakSession, clientSessionCtx);
+
+            apiFetchMock.verifyNoInteractions();
+
+            oidcMapperMock.verify(() ->
+                    OIDCAttributeMapperHelper.mapClaim(eq(token), eq(mappingModel), eq(fetchUrlResponse)));
+
+            verify(user).grantRole(roleModel);
+        }
+    }
+
+    @Test
+    public void setClaim_noCache_callsBackend_assignsRole_mapsClaim() {
+        Map<String, String> config = baseConfig();
+        setupCommonMocks(config);
+
+        when(userSession.getNote(anyString())).thenReturn(null);
+
+        try (MockedStatic<JsonHelper> jsonHelperMock = mockStatic(JsonHelper.class);
+             MockedStatic<ApiFetchHelper> apiFetchMock = mockStatic(ApiFetchHelper.class);
+             MockedStatic<OIDCAttributeMapperHelper> oidcMapperMock = mockStatic(OIDCAttributeMapperHelper.class)) {
+
+            jsonHelperMock.when(() -> JsonHelper.isPathExisting(anyString(), anyString()))
+                    .thenReturn(true);
+            jsonHelperMock.when(() -> JsonHelper.extractFromJson(anyString()))
+                    .thenReturn(fetchUrlResponse);
+            when(fetchUrlResponse.getMapToLmsRolle()).thenReturn("role-1");
+            when(clientModel.getRole("role-1")).thenReturn(roleModel);
+            when(user.hasRole(roleModel)).thenReturn(false);
+
+            apiFetchMock.when(() -> ApiFetchHelper.fetchApiData(anyString(), anyString(), anyString(), anyString(), anyInt()))
+                    .thenReturn("{\"ok\":true}");
+
+            IDToken token = new IDToken();
+            mapper.callSetClaim(token, mappingModel, userSession, keycloakSession, clientSessionCtx);
+
+            apiFetchMock.verify(() -> ApiFetchHelper.fetchApiData(
+                    eq("https://example.com/api"),
+                    eq("user-123"),
+                    eq("test-client"),
+                    eq("api-key"),
+                    eq(1500)));
+
+            verify(user).grantRole(roleModel);
+
+            oidcMapperMock.verify(() ->
+                    OIDCAttributeMapperHelper.mapClaim(eq(token), eq(mappingModel), eq(fetchUrlResponse)));
+
+            verify(userSession).setNote(eq("spsh_mapper_cache_value_mapper-id"), anyString());
+            verify(userSession).setNote(eq("spsh_mapper_cache_ts_mapper-id"), anyString());
+        }
+    }
+
+    @Test(expected = InternalServerErrorException.class)
+    public void setClaim_ignoreMissingTrue_pathMissing_throwsInternalServerError() {
+        Map<String, String> config = baseConfig();
+        config.put(IGNORE_MISSING_PATH, "true");
+        setupCommonMocks(config);
+
+        when(userSession.getNote(anyString())).thenReturn(null);
+
+        try (MockedStatic<JsonHelper> jsonHelperMock = mockStatic(JsonHelper.class);
+             MockedStatic<ApiFetchHelper> apiFetchMock = mockStatic(ApiFetchHelper.class)) {
+
+            jsonHelperMock.when(() -> JsonHelper.isPathExisting(anyString(), anyString()))
+                    .thenReturn(false);
+
+            apiFetchMock.when(() -> ApiFetchHelper.fetchApiData(anyString(), anyString(), anyString(), anyString(), anyInt()))
+                    .thenReturn("{\"other\":\"json\"}");
+
+            mapper.callSetClaim(new IDToken(), mappingModel, userSession, keycloakSession, clientSessionCtx);
+        }
+    }
+
+    @Test
+    public void setClaim_failModeAllowNoClaim_pathMissing_doesNotThrow() {
+        Map<String, String> config = baseConfig();
+        config.put(IGNORE_MISSING_PATH, "false");
+        config.put(FAIL_MODE, "allowNoClaim");
+        setupCommonMocks(config);
+
+        when(userSession.getNote(anyString())).thenReturn(null);
+
+        try (MockedStatic<JsonHelper> jsonHelperMock = mockStatic(JsonHelper.class);
+             MockedStatic<ApiFetchHelper> apiFetchMock = mockStatic(ApiFetchHelper.class)) {
+
+            jsonHelperMock.when(() -> JsonHelper.isPathExisting(anyString(), anyString()))
+                    .thenReturn(false);
+
+            apiFetchMock.when(() -> ApiFetchHelper.fetchApiData(anyString(), anyString(), anyString(), anyString(), anyInt()))
+                    .thenReturn("{\"other\":\"json\"}");
+
+            mapper.callSetClaim(new IDToken(), mappingModel, userSession, keycloakSession, clientSessionCtx);
+        }
+    }
+
+    @Test
+    public void setClaim_backendIOException_failModeAllowNoClaim_skipsClaim() {
+        Map<String, String> config = baseConfig();
+        config.put(FAIL_MODE, "allowNoClaim");
+        setupCommonMocks(config);
+
+        when(userSession.getNote(anyString())).thenReturn(null);
+
+        try (MockedStatic<JsonHelper> jsonHelperMock = mockStatic(JsonHelper.class);
+             MockedStatic<ApiFetchHelper> apiFetchMock = mockStatic(ApiFetchHelper.class)) {
+
+            jsonHelperMock.when(() -> JsonHelper.isPathExisting(anyString(), anyString()))
+                    .thenReturn(true);
+
+            apiFetchMock.when(() -> ApiFetchHelper.fetchApiData(anyString(), anyString(), anyString(), anyString(), anyInt()))
+                    .thenThrow(new IOException("backend down"));
+
+            mapper.callSetClaim(new IDToken(), mappingModel, userSession, keycloakSession, clientSessionCtx);
+        }
+    }
+
+    @Test
+    public void setClaim_roleNameBlank_skipsGrant() {
+        Map<String, String> config = baseConfig();
+        setupCommonMocks(config);
+        when(userSession.getNote(anyString())).thenReturn(null);
+
+        try (MockedStatic<JsonHelper> jsonHelperMock = mockStatic(JsonHelper.class);
+             MockedStatic<ApiFetchHelper> apiFetchMock = mockStatic(ApiFetchHelper.class)) {
+
+            jsonHelperMock.when(() -> JsonHelper.isPathExisting(anyString(), anyString()))
+                    .thenReturn(true);
+            jsonHelperMock.when(() -> JsonHelper.extractFromJson(anyString()))
+                    .thenReturn(fetchUrlResponse);
+            when(fetchUrlResponse.getMapToLmsRolle()).thenReturn("   ");
+
+            apiFetchMock.when(() -> ApiFetchHelper.fetchApiData(anyString(), anyString(), anyString(), anyString(), anyInt()))
+                    .thenReturn("{\"ok\":true}");
+
+            mapper.callSetClaim(new IDToken(), mappingModel, userSession, keycloakSession, clientSessionCtx);
+
+            verify(user, never()).grantRole(any());
+        }
+    }
+
+    @Test
+    public void setClaim_roleNotFound_skipsGrant() {
+        Map<String, String> config = baseConfig();
+        setupCommonMocks(config);
+        when(userSession.getNote(anyString())).thenReturn(null);
+
+        try (MockedStatic<JsonHelper> jsonHelperMock = mockStatic(JsonHelper.class);
+             MockedStatic<ApiFetchHelper> apiFetchMock = mockStatic(ApiFetchHelper.class)) {
+
+            jsonHelperMock.when(() -> JsonHelper.isPathExisting(anyString(), anyString()))
+                    .thenReturn(true);
+            jsonHelperMock.when(() -> JsonHelper.extractFromJson(anyString()))
+                    .thenReturn(fetchUrlResponse);
+            when(fetchUrlResponse.getMapToLmsRolle()).thenReturn("role-missing");
+            when(clientModel.getRole("role-missing")).thenReturn(null);
+
+            apiFetchMock.when(() -> ApiFetchHelper.fetchApiData(anyString(), anyString(), anyString(), anyString(), anyInt()))
+                    .thenReturn("{\"ok\":true}");
+
+            mapper.callSetClaim(new IDToken(), mappingModel, userSession, keycloakSession, clientSessionCtx);
+
+            verify(user, never()).grantRole(any());
+        }
+    }
+
+    @Test
+    public void setClaim_userAlreadyHasRole_doesNotGrantAgain() {
+        Map<String, String> config = baseConfig();
+        setupCommonMocks(config);
+        when(userSession.getNote(anyString())).thenReturn(null);
+
+        try (MockedStatic<JsonHelper> jsonHelperMock = mockStatic(JsonHelper.class);
+             MockedStatic<ApiFetchHelper> apiFetchMock = mockStatic(ApiFetchHelper.class)) {
+
+            jsonHelperMock.when(() -> JsonHelper.isPathExisting(anyString(), anyString()))
+                    .thenReturn(true);
+            jsonHelperMock.when(() -> JsonHelper.extractFromJson(anyString()))
+                    .thenReturn(fetchUrlResponse);
+            when(fetchUrlResponse.getMapToLmsRolle()).thenReturn("role-1");
+            when(clientModel.getRole("role-1")).thenReturn(roleModel);
+            when(user.hasRole(roleModel)).thenReturn(true);
+
+            apiFetchMock.when(() -> ApiFetchHelper.fetchApiData(anyString(), anyString(), anyString(), anyString(), anyInt()))
+                    .thenReturn("{\"ok\":true}");
+
+            mapper.callSetClaim(new IDToken(), mappingModel, userSession, keycloakSession, clientSessionCtx);
+
+            verify(user, never()).grantRole(any());
+        }
+    }
+}

--- a/src/test/java/com/spsh/oidc/dto/FetchUrlResponseTest.java
+++ b/src/test/java/com/spsh/oidc/dto/FetchUrlResponseTest.java
@@ -1,0 +1,28 @@
+package com.spsh.oidc.dto;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class FetchUrlResponseTest {
+
+    @Test
+    void testSetAndGetUserId() {
+        FetchUrlResponse response = new FetchUrlResponse();
+        response.setUserId("user-123");
+        assertEquals("user-123", response.getUserId());
+    }
+
+    @Test
+    void testSetAndGetMapToLmsRolle() {
+        FetchUrlResponse response = new FetchUrlResponse();
+        response.setMapToLmsRolle("Admin");
+        assertEquals("Admin", response.getMapToLmsRolle());
+    }
+
+    @Test
+    void testEmptyObject() {
+        FetchUrlResponse response = new FetchUrlResponse();
+        assertNull(response.getUserId());
+        assertNull(response.getMapToLmsRolle());
+    }
+}

--- a/src/test/java/com/spsh/util/JsonHelperTest.java
+++ b/src/test/java/com/spsh/util/JsonHelperTest.java
@@ -1,0 +1,99 @@
+package com.spsh.util;
+
+import com.jayway.jsonpath.PathNotFoundException;
+import com.spsh.oidc.dto.FetchUrlResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonHelperTest {
+
+    private String validJson;
+    private String missingFieldsJson;
+    private String emptyValuesJson;
+
+    @BeforeEach
+    void setUp() {
+        validJson = """
+        {
+          "userId": "user-123",
+          "mapToLmsRolle": "Admin"
+        }
+        """;
+
+        missingFieldsJson = """
+        {
+          "userId": "user-123"
+        }
+        """;
+
+        emptyValuesJson = """
+        {
+          "userId": "",
+          "mapToLmsRolle": ""
+        }
+        """;
+    }
+
+    // ---------------------------
+    // isPathExisting(...)
+    // ---------------------------
+
+    @Test
+    void isPathExisting_returnsTrue_whenPathIsPresent() {
+        boolean existsUserId = JsonHelper.isPathExisting(validJson, "$.userId");
+        boolean existsRole = JsonHelper.isPathExisting(validJson, "$.mapToLmsRolle");
+
+        assertTrue(existsUserId);
+        assertTrue(existsRole);
+    }
+
+    @Test
+    void isPathExisting_returnsFalse_whenPathIsMissing() {
+        boolean exists = JsonHelper.isPathExisting(missingFieldsJson, "$.mapToLmsRolle");
+        assertFalse(exists);
+    }
+
+    // ---------------------------
+    // extractFromJson(...)
+    // ---------------------------
+
+    @Test
+    void extractFromJson_returnsObject_whenAnyValueNonEmpty() {
+        FetchUrlResponse res = JsonHelper.extractFromJson(validJson);
+
+        assertNotNull(res, "Expected non-null FetchUrlResponse when values exist");
+        assertEquals("user-123", res.getUserId());
+        assertEquals("Admin", res.getMapToLmsRolle());
+    }
+
+    @Test
+    void extractFromJson_returnsNull_whenBothValuesAreEmptyStrings() {
+        FetchUrlResponse res = JsonHelper.extractFromJson(emptyValuesJson);
+        assertNull(res, "Expected null when both userId and mapToLmsRolle are empty");
+    }
+
+    @Test
+    void extractFromJson_throwsPathNotFound_whenFieldMissing() {
+        // Because extractFromJson() calls JsonPath.read(...) directly (no try/catch),
+        // a missing field leads to a PathNotFoundException.
+        assertThrows(PathNotFoundException.class, () -> JsonHelper.extractFromJson(missingFieldsJson));
+    }
+
+    // ---------------------------
+    // jsonString(...)
+    // ---------------------------
+
+    @Test
+    void jsonString_returnsQuotedAndEscapedValue() {
+        String input = "He said: \"Hi\" \\ ok";
+        String escaped = JsonHelper.jsonString(input);
+        assertEquals("\"He said: \\\"Hi\\\" \\\\ ok\"", escaped);
+    }
+
+    @Test
+    void jsonString_returnsLiteralNull_whenInputIsNull() {
+        assertEquals("null", JsonHelper.jsonString(null));
+    }
+}


### PR DESCRIPTION
# Description
SPSH Mapper is added again to be used for parallel operation between ErWIn Portal and SVS.
<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs
https://ticketsystem.dbildungscloud.de/browse/EW-1414
https://github.com/dBildungsplattform/erwin-portal-server/pull/44
https://github.com/dBildungsplattform/erwin-portal-keycloak/pull/16
<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.